### PR TITLE
fix: Stop deleting audiofiles after the deletion process was interrupted

### DIFF
--- a/backend/src/main/java/at/schulgong/controller/RingtoneController.java
+++ b/backend/src/main/java/at/schulgong/controller/RingtoneController.java
@@ -152,8 +152,8 @@ public class RingtoneController {
   ResponseEntity<?> deleteRingtone(@PathVariable long id) {
     if (ringtoneRepository.existsById(id)) {
       RingtoneDTO ringtoneDTO = one(id);
-      deleteAudioFile(ringtoneDTO.getPath());
       ringtoneRepository.deleteById(id);
+      deleteAudioFile(ringtoneDTO.getPath());
       return ResponseEntity.noContent().build();
     } else {
       throw new EntityNotFoundException(id, Config.RINGTONE.getException());


### PR DESCRIPTION
After interrupting the deletion process due to the blocking of a ringtime entry, not only the deletion process in the database is interrupted, but also the deletion process of the audio file

Issue: #4