### PR TITLE
fix: Problem with playing playlist after announcement

### DIFF
--- a/src/main/java/at/schulgong/speaker/api/PlayRingtones.java
+++ b/src/main/java/at/schulgong/speaker/api/PlayRingtones.java
@@ -256,6 +256,7 @@ public class PlayRingtones {
    * Play the announcement
    */
   public void playAnnouncement() {
+    isPlayingFromQueue = false;
     isPlayingAnnouncement = true;
     stopTasks();
     if (isPlayingAlarm) {
@@ -462,6 +463,8 @@ public class PlayRingtones {
     executeSpeakerAction(argsPlay);
     String[] argsSeek = new String[]{SpeakerCommand.SEEK.getCommand(), position};
     executeSpeakerAction(argsSeek);
+    isPlayingPlaylist = true;
+    isPlayingFromQueue = true;
   }
 
 }


### PR DESCRIPTION
Fixed that the announcement is playing when you want to start a playlist after playing an announcement.

"Issue: Closes #22"