### PR TITLE
fix: Deleting songs from database, which doesn't exists on the file system

### DIFF
--- a/src/main/java/at/schulgong/controller/LiveController.java
+++ b/src/main/java/at/schulgong/controller/LiveController.java
@@ -335,7 +335,7 @@ public class LiveController {
                     break;
                 }
             }
-            if (!songExist && (deleteAudioFile(song.getFilePath()))) {
+            if (!songExist && (Files.notExists(Paths.get(song.getFilePath())) || deleteAudioFile(song.getFilePath()))) {
                 songRepository.delete(song);
             }
         }


### PR DESCRIPTION
Added a condition that will be checked if the song exists on the file system. If not, the song will be deleted from the database.

Issue: Closes #44